### PR TITLE
delete :export-block

### DIFF
--- a/ox-novel.el
+++ b/ox-novel.el
@@ -42,7 +42,6 @@
     (template . org-novel-template)
     (verbatim . org-novel-verbatim)
     )
-  :export-block "NOVEL"
   :menu-entry
   '(?n "Export to Novel"
        (


### PR DESCRIPTION
Emacs 24.5.1
Org-mode 9.0.7
において、ox-novelのrequireをしたところ、

```
Debugger entered--Lisp error: (error "Unknown keyword: :export-block")
```

のエラーが発生しました。

yjwen/org-reveal#185

このissueを参考に:export-blockを削除したところ、エラーを回避することが出来ました。